### PR TITLE
Fix directory handling issues under lazy loading

### DIFF
--- a/pyfatfs/FATDirectoryEntry.py
+++ b/pyfatfs/FATDirectoryEntry.py
@@ -376,11 +376,14 @@ class FATDirectoryEntry:
 
         clus = self.get_cluster()
         self.__dirs = self.__fs.parse_dir_entries_in_cluster_chain(clus)
+        for dir_entry in self.__dirs:
+            dir_entry._add_parent(self)
 
-    def _get_entries_raw(self):
+    def _get_entries_raw(self, populate: bool = True):
         """Get a full list of entries in current directory."""
         self._verify_is_directory()
-        self.__populate_dirs()
+        if populate:
+            self.__populate_dirs()
 
         return self.__dirs
 

--- a/pyfatfs/PyFat.py
+++ b/pyfatfs/PyFat.py
@@ -591,7 +591,7 @@ class PyFat(object):
 
         # Gather all directory entries
         dir_entries = b''
-        for d in dir_entry._get_entries_raw():
+        for d in dir_entry._get_entries_raw(populate=False):
             dir_entries += bytes(d)
 
         # Write content


### PR DESCRIPTION
- Set the parent directory during populate_dirs (this is done in add_subdirectory() for non-lazy loading)
- Don't repopulate the directory structure from disk when there is a pending entry change